### PR TITLE
Update the requirements.txt for setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ rospkg==1.4.0
 defusedxml==0.7.1
 tslearn==0.5.2
 h5py==3.9.0
-setuptools==39.0.1
+setuptools==75.1.0
 requests~=2.18.4
 bagpy==0.5


### PR DESCRIPTION
Dear Author,

We have recently been testing this project, and during the environment setup referred in https://github.com/skhatiri/Aerialist?tab=readme-ov-file#using-hosts-cli, we noticed that the current requirements.txt specifies setuptools==39.0.1, which may be outdated and causing some issues. Specifically, when installing the CLI in Host Linux using the following command (instance encapsulated in docker's condition):

```bash
pip3 install git+https://github.com/skhatiri/Aerialist.git
```
Setuptools version 39.0.1 results in the error:
```
(air2) lilejin@lilejin-Tower:~/DroneLearn$ pip3 install git+https://github.com/skhatiri/Aerialist.git
Error processing line 1 of /home/lilejin/anaconda3/envs/air2/lib/python3.9/site-packages/distutils-precedence.pth:

  Traceback (most recent call last):
    File "/home/lilejin/anaconda3/envs/air2/lib/python3.9/site.py", line 177, in addpackage
      exec(line)
    File "<string>", line 1, in <module>
  ModuleNotFoundError: No module named '_distutils_hack'

Remainder of file ignored
Collecting git+https://github.com/skhatiri/Aerialist.git
  Cloning https://github.com/skhatiri/Aerialist.git to /tmp/pip-req-build-35oyi991
  Running command git clone --filter=blob:none --quiet https://github.com/skhatiri/Aerialist.git /tmp/pip-req-build-35oyi991
  Resolved https://github.com/skhatiri/Aerialist.git to commit 3efcc1bf1db204dc3ba59e28319763e72c3de556
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [21 lines of output]
      Error processing line 1 of /home/lilejin/anaconda3/envs/air2/lib/python3.9/site-packages/distutils-precedence.pth:
      
        Traceback (most recent call last):
          File "/home/lilejin/anaconda3/envs/air2/lib/python3.9/site.py", line 177, in addpackage
            exec(line)
          File "<string>", line 1, in <module>
        ModuleNotFoundError: No module named '_distutils_hack'
      
      Remainder of file ignored
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 14, in <module>
        File "/home/lilejin/anaconda3/envs/air2/lib/python3.9/site-packages/setuptools/__init__.py", line 14, in <module>
          from setuptools.dist import Distribution, Feature
        File "/home/lilejin/anaconda3/envs/air2/lib/python3.9/site-packages/setuptools/dist.py", line 24, in <module>
          from setuptools.depends import Require
        File "/home/lilejin/anaconda3/envs/air2/lib/python3.9/site-packages/setuptools/depends.py", line 7, in <module>
          from .py33compat import Bytecode
        File "/home/lilejin/anaconda3/envs/air2/lib/python3.9/site-packages/setuptools/py33compat.py", line 54, in <module>
          unescape = getattr(html, 'unescape', html_parser.HTMLParser().unescape)
      AttributeError: 'HTMLParser' object has no attribute 'unescape'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

After using the command ```pip install setuptools --upgrade```, the issue was resolved by setuptools==75.1.0. Could you please consider checking if this dependency is outdated? :computer:

Once again, we sincerely appreciate your contribution to UAV software testing.

Best regards,
Lejin
Kyushu University, Japan